### PR TITLE
Fix refresh timer

### DIFF
--- a/openidconnect/lib/src/openidconnect_client.dart
+++ b/openidconnect/lib/src/openidconnect_client.dart
@@ -357,8 +357,8 @@ class OpenIdConnectClient {
       await _completeLogin(response);
 
       if (autoRefresh) {
-        final refreshTime = _identity!.expiresAt
-            .difference(DateTime.now().subtract(Duration(minutes: 1)));
+        var refreshTime = _identity!.expiresAt.difference(DateTime.now().toUtc());
+        refreshTime -= Duration(minutes: 1);
 
         _autoRenewTimer = Future.delayed(refreshTime, refresh);
       }


### PR DESCRIPTION
The `refreshTime` in the `refresh()` method was being calculated incorrectly, and therefore the token refresh was not taking place before the token expiration time. This fixes the problem by implementing a calculation similar to the one found in the same file in `_setupAutoRenew()`