### PR TITLE
Isolate persisted client credentials by tenant id

### DIFF
--- a/openidconnect/README.md
+++ b/openidconnect/README.md
@@ -65,6 +65,7 @@ Currently supports:
    - `loginWithDeviceCode` / device-code helpers for device flow
 4. If you already call `initalizeEncryption(...)` or pass an `encryptionKey` into `OpenIdConnectClient.create(...)`, you can keep doing so while upgrading. Those APIs are compatibility no-ops in `2.x` because secure storage is handled internally by the endorsed platform implementations.
 5. Review the platform configuration notes below before testing interactive login.
+6. If you need multiple `OpenIdConnectClient` instances to keep separate persisted credentials, provide a distinct `tenantId` to each client. When `tenantId` is null, the library uses the legacy global storage keys.
 
 ## Platform configuration
 

--- a/openidconnect/lib/openidconnect_client.dart
+++ b/openidconnect/lib/openidconnect_client.dart
@@ -14,6 +14,7 @@ class OpenIdConnectClient {
   final String discoveryDocumentUrl;
   final String clientId;
   final String? clientSecret;
+  final String? tenantId;
   final String? redirectUrl;
   final bool autoRefresh;
   final bool webUseRefreshTokens;
@@ -32,6 +33,7 @@ class OpenIdConnectClient {
   OpenIdConnectClient._({
     required this.discoveryDocumentUrl,
     required this.clientId,
+    this.tenantId,
     this.redirectUrl,
     this.clientSecret,
     this.autoRefresh = true,
@@ -46,6 +48,7 @@ class OpenIdConnectClient {
     required String discoveryDocumentUrl,
     required String clientId,
     required String encryptionKey,
+    String? tenantId,
     String? redirectUrl,
     String? clientSecret,
     bool autoRefresh = true,
@@ -58,6 +61,7 @@ class OpenIdConnectClient {
     final client = OpenIdConnectClient._(
       discoveryDocumentUrl: discoveryDocumentUrl,
       clientId: clientId,
+      tenantId: tenantId,
       clientSecret: clientSecret,
       redirectUrl: redirectUrl,
       scopes: scopes,
@@ -85,11 +89,11 @@ class OpenIdConnectClient {
 
       if (response != null) {
         _identity = OpenIdIdentity.fromAuthorizationResponse(response);
-        await this._identity?.save();
+        await this._identity?.save(tenantId: tenantId);
       }
     }
 
-    if (_identity == null) _identity = await OpenIdIdentity.load();
+    if (_identity == null) _identity = await OpenIdIdentity.load(tenantId: tenantId);
     _isInitializationComplete = true;
 
     if (_identity != null) {
@@ -480,7 +484,7 @@ class OpenIdConnectClient {
     if (!webUseRefreshTokens) {
       //Web has a special case where it will use a hidden iframe. This just returns true because the iframe does it.
       //In this case we simply load from storage because the web implementation just stores the new values in storage for us.
-      _identity = await OpenIdIdentity.load();
+      _identity = await OpenIdIdentity.load(tenantId: tenantId);
       return true;
     }
 
@@ -549,7 +553,7 @@ class OpenIdConnectClient {
   /// Clears the persisted identity from storage and memory.
   Future<void> clearIdentity() async {
     if (this._identity != null) {
-      await OpenIdIdentity.clear();
+      await OpenIdIdentity.clear(tenantId: tenantId);
       this._identity = null;
     }
   }
@@ -562,7 +566,7 @@ class OpenIdConnectClient {
   Future<void> _completeLogin(AuthorizationResponse response) async {
     this._identity = OpenIdIdentity.fromAuthorizationResponse(response);
 
-    await this._identity!.save();
+    await this._identity!.save(tenantId: tenantId);
   }
 
   Future<bool> _setupAutoRenew() async {

--- a/openidconnect/lib/src/models/identity.dart
+++ b/openidconnect/lib/src/models/identity.dart
@@ -51,7 +51,7 @@ class OpenIdIdentity extends AuthorizationResponse {
   );
 
   /// Loads a previously persisted identity from secure storage.
-  static Future<OpenIdIdentity?> load() async {
+  static Future<OpenIdIdentity?> load({String? tenantId}) async {
     try {
       late String? accessToken;
       late String? refreshToken;
@@ -61,17 +61,26 @@ class OpenIdIdentity extends AuthorizationResponse {
       late String? state;
 
       accessToken = await _OpenIdConnectSecureStorage.getString(
-        _AUTHENTICATION_TOKEN_KEY,
+        _storageKey(_AUTHENTICATION_TOKEN_KEY, tenantId),
       );
-      idToken = await _OpenIdConnectSecureStorage.getString(_ID_TOKEN_KEY);
+      idToken = await _OpenIdConnectSecureStorage.getString(
+        _storageKey(_ID_TOKEN_KEY, tenantId),
+      );
       expiresOn =
-          await _OpenIdConnectSecureStorage.getInt(_EXPIRES_ON_KEY) ?? 0;
+          await _OpenIdConnectSecureStorage.getInt(
+            _storageKey(_EXPIRES_ON_KEY, tenantId),
+          ) ??
+          0;
       tokenType =
-          await _OpenIdConnectSecureStorage.getString(_TOKEN_TYPE_KEY) ??
+          await _OpenIdConnectSecureStorage.getString(
+            _storageKey(_TOKEN_TYPE_KEY, tenantId),
+          ) ??
           "bearer";
-      state = await _OpenIdConnectSecureStorage.getString(_STATE_KEY);
+      state = await _OpenIdConnectSecureStorage.getString(
+        _storageKey(_STATE_KEY, tenantId),
+      );
       refreshToken = await _OpenIdConnectSecureStorage.getString(
-        _REFRESH_TOKEN_KEY,
+        _storageKey(_REFRESH_TOKEN_KEY, tenantId),
       );
 
       if (accessToken == null || idToken == null) return null;
@@ -86,49 +95,75 @@ class OpenIdIdentity extends AuthorizationResponse {
       );
     } on Exception {
       try {
-        clear();
+        clear(tenantId: tenantId);
       } on Exception {}
       return null; //Invalid values, flush.
     }
   }
 
   /// Persists this identity to secure storage.
-  Future<void> save() async {
+  Future<void> save({String? tenantId}) async {
     await Future.wait([
       _OpenIdConnectSecureStorage.setString(
-        _AUTHENTICATION_TOKEN_KEY,
+        _storageKey(_AUTHENTICATION_TOKEN_KEY, tenantId),
         this.accessToken,
       ),
-      _OpenIdConnectSecureStorage.setString(_ID_TOKEN_KEY, this.idToken),
-      _OpenIdConnectSecureStorage.setString(_TOKEN_TYPE_KEY, this.tokenType),
+      _OpenIdConnectSecureStorage.setString(
+        _storageKey(_ID_TOKEN_KEY, tenantId),
+        this.idToken,
+      ),
+      _OpenIdConnectSecureStorage.setString(
+        _storageKey(_TOKEN_TYPE_KEY, tenantId),
+        this.tokenType,
+      ),
       _OpenIdConnectSecureStorage.setInt(
-        _EXPIRES_ON_KEY,
+        _storageKey(_EXPIRES_ON_KEY, tenantId),
         this.expiresAt.millisecondsSinceEpoch,
       ),
     ]);
 
     this.refreshToken == null
-        ? await _OpenIdConnectSecureStorage.remove(_REFRESH_TOKEN_KEY)
+        ? await _OpenIdConnectSecureStorage.remove(
+            _storageKey(_REFRESH_TOKEN_KEY, tenantId),
+          )
         : await _OpenIdConnectSecureStorage.setString(
-            _REFRESH_TOKEN_KEY,
+            _storageKey(_REFRESH_TOKEN_KEY, tenantId),
             this.refreshToken!,
           );
 
     this.state == null
-        ? await _OpenIdConnectSecureStorage.remove(_STATE_KEY)
-        : await _OpenIdConnectSecureStorage.setString(_STATE_KEY, this.state!);
+        ? await _OpenIdConnectSecureStorage.remove(
+            _storageKey(_STATE_KEY, tenantId),
+          )
+        : await _OpenIdConnectSecureStorage.setString(
+            _storageKey(_STATE_KEY, tenantId),
+            this.state!,
+          );
   }
 
   /// Removes any persisted identity from secure storage.
-  static Future<void> clear() async {
+  static Future<void> clear({String? tenantId}) async {
     await Future.wait([
-      _OpenIdConnectSecureStorage.remove(_AUTHENTICATION_TOKEN_KEY),
-      _OpenIdConnectSecureStorage.remove(_ID_TOKEN_KEY),
-      _OpenIdConnectSecureStorage.remove(_REFRESH_TOKEN_KEY),
-      _OpenIdConnectSecureStorage.remove(_TOKEN_TYPE_KEY),
-      _OpenIdConnectSecureStorage.remove(_EXPIRES_ON_KEY),
-      _OpenIdConnectSecureStorage.remove(_STATE_KEY),
+      _OpenIdConnectSecureStorage.remove(
+        _storageKey(_AUTHENTICATION_TOKEN_KEY, tenantId),
+      ),
+      _OpenIdConnectSecureStorage.remove(_storageKey(_ID_TOKEN_KEY, tenantId)),
+      _OpenIdConnectSecureStorage.remove(
+        _storageKey(_REFRESH_TOKEN_KEY, tenantId),
+      ),
+      _OpenIdConnectSecureStorage.remove(
+        _storageKey(_TOKEN_TYPE_KEY, tenantId),
+      ),
+      _OpenIdConnectSecureStorage.remove(
+        _storageKey(_EXPIRES_ON_KEY, tenantId),
+      ),
+      _OpenIdConnectSecureStorage.remove(_storageKey(_STATE_KEY, tenantId)),
     ]);
+  }
+
+  static String _storageKey(String key, String? tenantId) {
+    if (tenantId == null || tenantId.isEmpty) return key;
+    return '$key-$tenantId';
   }
 
   /// The `family_name` claim from the ID token, if present.

--- a/openidconnect/test/openidconnect_client_test.dart
+++ b/openidconnect/test/openidconnect_client_test.dart
@@ -129,6 +129,66 @@ void main() {
       expect(await OpenIdIdentity.load(), isNull);
     });
 
+    test('loads isolated identities for different tenant ids', () async {
+      await _saveIdentity(
+        accessToken: 'tenant-a-access-token',
+        expiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+        tenantId: 'tenant-a',
+      );
+      await _saveIdentity(
+        accessToken: 'tenant-b-access-token',
+        expiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+        tenantId: 'tenant-b',
+      );
+
+      final tenantAClient = await OpenIdConnectClient.create(
+        discoveryDocumentUrl: 'https://issuer.example.com/.well-known/openid',
+        clientId: 'client-id',
+        encryptionKey: 'unused',
+        tenantId: 'tenant-a',
+        autoRefresh: false,
+      );
+      final tenantBClient = await OpenIdConnectClient.create(
+        discoveryDocumentUrl: 'https://issuer.example.com/.well-known/openid',
+        clientId: 'client-id',
+        encryptionKey: 'unused',
+        tenantId: 'tenant-b',
+        autoRefresh: false,
+      );
+      addTearDown(tenantAClient.dispose);
+      addTearDown(tenantBClient.dispose);
+
+      expect(tenantAClient.identity?.accessToken, 'tenant-a-access-token');
+      expect(tenantBClient.identity?.accessToken, 'tenant-b-access-token');
+    });
+
+    test('clearIdentity clears only the matching tenant namespace', () async {
+      await _saveIdentity(
+        accessToken: 'tenant-a-access-token',
+        expiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+        tenantId: 'tenant-a',
+      );
+      await _saveIdentity(
+        accessToken: 'tenant-b-access-token',
+        expiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+        tenantId: 'tenant-b',
+      );
+
+      final tenantAClient = await OpenIdConnectClient.create(
+        discoveryDocumentUrl: 'https://issuer.example.com/.well-known/openid',
+        clientId: 'client-id',
+        encryptionKey: 'unused',
+        tenantId: 'tenant-a',
+        autoRefresh: false,
+      );
+      addTearDown(tenantAClient.dispose);
+
+      await tenantAClient.clearIdentity();
+
+      expect(await OpenIdIdentity.load(tenantId: 'tenant-a'), isNull);
+      expect(await OpenIdIdentity.load(tenantId: 'tenant-b'), isNotNull);
+    });
+
     test('publishes reported errors to the event stream', () async {
       final client = await OpenIdConnectClient.create(
         discoveryDocumentUrl: 'https://issuer.example.com/.well-known/openid',
@@ -216,12 +276,16 @@ void main() {
   });
 }
 
-Future<void> _saveIdentity({required DateTime expiresAt}) {
+Future<void> _saveIdentity({
+  required DateTime expiresAt,
+  String accessToken = 'access-token',
+  String? tenantId,
+}) {
   return OpenIdIdentity(
-    accessToken: 'access-token',
+    accessToken: accessToken,
     expiresAt: expiresAt,
     idToken: _testIdToken,
     tokenType: 'Bearer',
     refreshToken: 'refresh-token',
-  ).save();
+  ).save(tenantId: tenantId);
 }

--- a/openidconnect/test/openidconnect_test.dart
+++ b/openidconnect/test/openidconnect_test.dart
@@ -81,6 +81,50 @@ void main() {
       expect(loaded, isNot(null));
     });
 
+    test('load namespaced identities independently', () async {
+      await OpenIdIdentity(
+        accessToken: 'tenant_a_testing_access_token',
+        expiresAt: DateTime.now(),
+        idToken: TEST_ID_TOKEN,
+        tokenType: 'Bearer',
+      ).save(tenantId: 'tenant-a');
+      await OpenIdIdentity(
+        accessToken: 'tenant_b_testing_access_token',
+        expiresAt: DateTime.now(),
+        idToken: TEST_ID_TOKEN,
+        tokenType: 'Bearer',
+      ).save(tenantId: 'tenant-b');
+
+      expect(
+        (await OpenIdIdentity.load(tenantId: 'tenant-a'))?.accessToken,
+        'tenant_a_testing_access_token',
+      );
+      expect(
+        (await OpenIdIdentity.load(tenantId: 'tenant-b'))?.accessToken,
+        'tenant_b_testing_access_token',
+      );
+    });
+
+    test('clear only removes keys for the provided tenant id', () async {
+      await OpenIdIdentity(
+        accessToken: 'tenant_a_testing_access_token',
+        expiresAt: DateTime.now(),
+        idToken: TEST_ID_TOKEN,
+        tokenType: 'Bearer',
+      ).save(tenantId: 'tenant-a');
+      await OpenIdIdentity(
+        accessToken: 'tenant_b_testing_access_token',
+        expiresAt: DateTime.now(),
+        idToken: TEST_ID_TOKEN,
+        tokenType: 'Bearer',
+      ).save(tenantId: 'tenant-b');
+
+      await OpenIdIdentity.clear(tenantId: 'tenant-a');
+
+      expect(await OpenIdIdentity.load(tenantId: 'tenant-a'), isNull);
+      expect(await OpenIdIdentity.load(tenantId: 'tenant-b'), isNotNull);
+    });
+
     test('clears invalid stored identity values', () async {
       storage['ACCESS_TOKEN'] = 'stale-access-token';
       storage['ID_TOKEN'] = 'not-a-jwt';


### PR DESCRIPTION
## Summary
- add optional `tenantId` support to `OpenIdConnectClient.create(...)`
- keep legacy global storage keys when `tenantId` is null
- suffix persisted identity keys with `-tenantId` when provided so multiple clients do not share credentials
- add tests covering isolated loads and clears across tenants

## Validation
- `cd openidconnect && flutter test`

Closes #34