### PR TITLE
Await invalid identity cleanup

### DIFF
--- a/openidconnect/lib/src/models/identity.dart
+++ b/openidconnect/lib/src/models/identity.dart
@@ -95,7 +95,7 @@ class OpenIdIdentity extends AuthorizationResponse {
       );
     } on Exception {
       try {
-        clear(tenantId: tenantId);
+        await clear(tenantId: tenantId);
       } on Exception {}
       return null; //Invalid values, flush.
     }

--- a/openidconnect/test/openidconnect_test.dart
+++ b/openidconnect/test/openidconnect_test.dart
@@ -40,7 +40,7 @@ void main() {
               if (deleteDelay > Duration.zero) {
                 await Future<void>.delayed(deleteDelay);
               }
-              storage.remove(key);
+              storage.remove(key!);
               return null;
             case 'deleteAll':
               storage.clear();
@@ -142,18 +142,22 @@ void main() {
       expect(storage, isEmpty);
     });
 
-    test('awaits clearing invalid stored identity values before returning', () async {
-      deleteDelay = const Duration(milliseconds: 10);
-      storage['ACCESS_TOKEN'] = 'stale-access-token';
-      storage['ID_TOKEN'] = 'not-a-jwt';
-      storage['EXPIRES_ON'] = DateTime.now().millisecondsSinceEpoch.toString();
-      storage['TOKEN_TYPE'] = 'Bearer';
+    test(
+      'awaits clearing invalid stored identity values before returning',
+      () async {
+        deleteDelay = const Duration(milliseconds: 10);
+        storage['ACCESS_TOKEN'] = 'stale-access-token';
+        storage['ID_TOKEN'] = 'not-a-jwt';
+        storage['EXPIRES_ON'] = DateTime.now().millisecondsSinceEpoch
+            .toString();
+        storage['TOKEN_TYPE'] = 'Bearer';
 
-      final loaded = await OpenIdIdentity.load();
+        final loaded = await OpenIdIdentity.load();
 
-      expect(loaded, isNull);
-      expect(storage, isEmpty);
-    });
+        expect(loaded, isNull);
+        expect(storage, isEmpty);
+      },
+    );
 
     test('exposes identity claims via convenience getters', () {
       final identity = OpenIdIdentity(

--- a/openidconnect/test/openidconnect_test.dart
+++ b/openidconnect/test/openidconnect_test.dart
@@ -15,9 +15,11 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   final storage = <String, String>{};
+  var deleteDelay = Duration.zero;
 
   setUp(() {
     storage.clear();
+    deleteDelay = Duration.zero;
 
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(_secureStorageChannel, (call) async {
@@ -35,6 +37,9 @@ void main() {
             case 'read':
               return storage[key];
             case 'delete':
+              if (deleteDelay > Duration.zero) {
+                await Future<void>.delayed(deleteDelay);
+              }
               storage.remove(key);
               return null;
             case 'deleteAll':
@@ -126,6 +131,19 @@ void main() {
     });
 
     test('clears invalid stored identity values', () async {
+      storage['ACCESS_TOKEN'] = 'stale-access-token';
+      storage['ID_TOKEN'] = 'not-a-jwt';
+      storage['EXPIRES_ON'] = DateTime.now().millisecondsSinceEpoch.toString();
+      storage['TOKEN_TYPE'] = 'Bearer';
+
+      final loaded = await OpenIdIdentity.load();
+
+      expect(loaded, isNull);
+      expect(storage, isEmpty);
+    });
+
+    test('awaits clearing invalid stored identity values before returning', () async {
+      deleteDelay = const Duration(milliseconds: 10);
       storage['ACCESS_TOKEN'] = 'stale-access-token';
       storage['ID_TOKEN'] = 'not-a-jwt';
       storage['EXPIRES_ON'] = DateTime.now().millisecondsSinceEpoch.toString();


### PR DESCRIPTION
## Summary
- await secure-storage cleanup when `OpenIdIdentity.load(...)` encounters invalid persisted values
- add a regression test that delays delete operations to prove cleanup finishes before `load` returns

## Validation
- `cd openidconnect && flutter test test/openidconnect_test.dart test/openidconnect_client_test.dart`