### PR TITLE
Fix Android JVM target mismatch

### DIFF
--- a/openidconnect/example/ios/Podfile
+++ b/openidconnect/example/ios/Podfile
@@ -1,5 +1,4 @@
-# Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -31,9 +30,6 @@ target 'Runner' do
   use_frameworks!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
-  target 'RunnerTests' do
-    inherit! :search_paths
-  end
 end
 
 post_install do |installer|

--- a/openidconnect_android/android/build.gradle
+++ b/openidconnect_android/android/build.gradle
@@ -29,12 +29,12 @@ android {
     compileSdk 36
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {

--- a/openidconnect_android/android/build.gradle
+++ b/openidconnect_android/android/build.gradle
@@ -28,6 +28,15 @@ android {
     namespace "io.concerti.openidconnect_android"
     compileSdk 36
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/openidconnect_android/android/build.gradle
+++ b/openidconnect_android/android/build.gradle
@@ -29,12 +29,12 @@ android {
     compileSdk 36
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '1.8'
     }
 
     sourceSets {

--- a/openidconnect_linux/linux/openidconnect_linux_plugin.cc
+++ b/openidconnect_linux/linux/openidconnect_linux_plugin.cc
@@ -6,7 +6,6 @@
 
 #define OPENIDCONNECT_SCHEMA openidconnect_get_schema()
 
-const char kBadArgumentsError[] = "Bad Arguments";
 const char kSecurityAccessError[] = "Security Access Error";
 const char kMethodInitialize[] = "initialize";
 const char kMethodRead[] = "read";


### PR DESCRIPTION
## Summary
- align the Android plugin Java compile target with Kotlins JVM 17 target
- fix the example appbundle CI failure on current main

## Validation
- flutter build appbundle (from openidconnect/example)
- ./gradlew :openidconnect_android:compileReleaseKotlin --console=plain (from openidconnect/example/android)
